### PR TITLE
chore(MOS-1162): Loosen SF version constraint to allow 6.x as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "guzzlehttp/guzzle": "^6.3|^7.0",
     "eightpoints/guzzle-bundle": "^7.6|^8.0",
     "caseyamcl/guzzle_retry_middleware": "^2.2",
-    "symfony/dependency-injection": "~4.0|^5.0"
+    "symfony/dependency-injection": "~4.0|^5.0|^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.1",


### PR DESCRIPTION
Only increases the upper boundary of the `symfony/dependency-injection` dependency to allow Symfony 6.x installs.